### PR TITLE
Added double quotes around the path arguments for the jekyll call

### DIFF
--- a/morea-run-local.sh
+++ b/morea-run-local.sh
@@ -8,4 +8,4 @@ fi
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 set -x
-jekyll serve --source $DIR/master/src --destination $DIR/master/src/_site --baseurl "" --watch
+jekyll serve --source "$DIR/master/src" --destination "$DIR/master/src/_site" --baseurl "" --watch


### PR DESCRIPTION
Added double quotes around the path arguments for the jekyll call to support spaces in the path
